### PR TITLE
Making moveit_setup_assistant required in setup_assistant.launch

### DIFF
--- a/launch/setup_assistant.launch
+++ b/launch/setup_assistant.launch
@@ -9,6 +9,6 @@
   <!-- Run -->
   <node pkg="moveit_setup_assistant" type="moveit_setup_assistant" name="moveit_setup_assistant" 
 	launch-prefix="$(arg launch_prefix)"
-        output="screen" />
+        output="screen"  required="true" />
 
 </launch>


### PR DESCRIPTION
This way, roslaunch will always exit after you close the setup assistant.
