### PR TITLE
Added 2 deps needed for some of the launch files generated by the setup assistant

### DIFF
--- a/templates/moveit_config_pkg_template/package.xml.template
+++ b/templates/moveit_config_pkg_template/package.xml.template
@@ -15,6 +15,8 @@
   <url type="repository">https://github.com/ros-planning/moveit_setup_assistant</url>
 
   <run_depend>moveit_ros_move_group</run_depend>
+  <run_depend>moveit_planners_ompl</run_depend>
+  <run_depend>moveit_ros_visualization</run_depend>
   <run_depend>joint_state_publisher</run_depend>
   <run_depend>robot_state_publisher</run_depend>
   <run_depend>xacro</run_depend>


### PR DESCRIPTION
Otherwise errors are generated at roslaunch. This allows `rosdep install` to work properly.
