### PR TITLE
Fix compilation on OS X 10.9 (clang) and Arch Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,6 +78,7 @@ add_library(${PROJECT_NAME}_widgets
   src/widgets/header_widget.cpp
   src/widgets/setup_assistant_widget.cpp
   src/widgets/setup_screen_widget.cpp
+  ${moc_sources}
 )
 target_link_libraries(${PROJECT_NAME}_widgets ${PROJECT_NAME}_tools ${QT_LIBRARIES} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
@@ -90,16 +91,16 @@ catkin_package(
   INCLUDE_DIRS
     include
   LIBRARIES
-    ${PROJECT_NAME}_tools 
+    ${PROJECT_NAME}_tools
   CATKIN_DEPENDS
     moveit_ros_planning
     moveit_ros_visualization
     )
 
 # Link libraries
-add_executable(${PROJECT_NAME} ${sources} ${headers} ${moc_sources})
-target_link_libraries(${PROJECT_NAME} 
-  ${PROJECT_NAME}_widgets ${PROJECT_NAME}_tools 
+add_executable(${PROJECT_NAME} ${sources} ${headers})
+target_link_libraries(${PROJECT_NAME}
+  ${PROJECT_NAME}_widgets ${PROJECT_NAME}_tools
   ${QT_LIBRARIES} ${catkin_LIBRARIES} ${Boost_LIBRARIES} log4cxx)
 
 install(TARGETS ${PROJECT_NAME} ${PROJECT_NAME}_widgets ${PROJECT_NAME}_tools

--- a/src/widgets/configuration_files_widget.h
+++ b/src/widgets/configuration_files_widget.h
@@ -44,7 +44,11 @@
 #include <QLabel>
 #include <QListWidget>
 #include <QList>
+
+#ifndef Q_MOC_RUN
 #include <moveit/setup_assistant/tools/moveit_config_data.h>
+#endif
+
 #include "header_widget.h"
 #include "setup_screen_widget.h" // a base class for screens in the setup assistant
 

--- a/src/widgets/default_collisions_widget.h
+++ b/src/widgets/default_collisions_widget.h
@@ -47,9 +47,13 @@
 #include <QProgressBar>
 #include <QCheckBox>
 #include <QSpinBox>
+
+#ifndef Q_MOC_RUN
 #include <boost/thread.hpp>
 #include <moveit/setup_assistant/tools/compute_default_collisions.h>
 #include <moveit/setup_assistant/tools/moveit_config_data.h>
+#endif
+
 #include "header_widget.h"
 #include "setup_screen_widget.h" // a base class for screens in the setup assistant
 

--- a/src/widgets/double_list_widget.h
+++ b/src/widgets/double_list_widget.h
@@ -40,7 +40,10 @@
 #include <QWidget>
 #include <QLabel>
 #include <QTableWidget>
+
+#ifndef Q_MOC_RUN
 #include <moveit/setup_assistant/tools/moveit_config_data.h>
+#endif
 
 namespace moveit_setup_assistant
 {

--- a/src/widgets/end_effectors_widget.h
+++ b/src/widgets/end_effectors_widget.h
@@ -49,8 +49,12 @@
 #include <QStackedLayout>
 #include <QString>
 #include <QComboBox>
+
 // SA
+#ifndef Q_MOC_RUN
 #include <moveit/setup_assistant/tools/moveit_config_data.h>
+#endif
+
 #include "header_widget.h"
 #include "setup_screen_widget.h" // a base class for screens in the setup assistant
 

--- a/src/widgets/group_edit_widget.h
+++ b/src/widgets/group_edit_widget.h
@@ -42,7 +42,10 @@
 #include <QLineEdit>
 #include <QComboBox>
 #include <QPushButton>
+
+#ifndef Q_MOC_RUN
 #include <moveit/setup_assistant/tools/moveit_config_data.h>
+#endif
 
 namespace moveit_setup_assistant
 {

--- a/src/widgets/kinematic_chain_widget.h
+++ b/src/widgets/kinematic_chain_widget.h
@@ -40,8 +40,11 @@
 #include <QWidget>
 #include <QLabel>
 #include <QTreeWidget>
+
+#ifndef Q_MOC_RUN
 #include <moveit/setup_assistant/tools/moveit_config_data.h>
 #include <ros/ros.h>
+#endif
 
 namespace moveit_setup_assistant
 {

--- a/src/widgets/passive_joints_widget.h
+++ b/src/widgets/passive_joints_widget.h
@@ -47,8 +47,12 @@
 #include <QStackedLayout>
 #include <QString>
 #include <QComboBox>
+
 // SA
+#ifndef Q_MOC_RUN
 #include <moveit/setup_assistant/tools/moveit_config_data.h>
+#endif
+
 #include "header_widget.h"
 #include "double_list_widget.h"
 #include "setup_screen_widget.h" // a base class for screens in the setup assistant

--- a/src/widgets/planning_groups_widget.h
+++ b/src/widgets/planning_groups_widget.h
@@ -42,8 +42,12 @@
 #include <QTreeWidget>
 #include <QSplitter>
 #include <QStackedLayout>
+
 // Setup Asst
+#ifndef Q_MOC_RUN
 #include <moveit/setup_assistant/tools/moveit_config_data.h>
+#endif
+
 #include "double_list_widget.h" // for joints, links and subgroups pages
 #include "kinematic_chain_widget.h" // for kinematic chain page
 #include "group_edit_widget.h" // for group rename page

--- a/src/widgets/robot_poses_widget.h
+++ b/src/widgets/robot_poses_widget.h
@@ -49,12 +49,16 @@
 #include <QStackedLayout>
 #include <QString>
 #include <QComboBox>
+
 // SA
+#ifndef Q_MOC_RUN
 #include <moveit/setup_assistant/tools/moveit_config_data.h>
 #include <moveit/planning_scene/planning_scene.h> // for collision stuff
+#include <ros/ros.h>
+#endif
+
 #include "header_widget.h"
 #include "setup_screen_widget.h" // a base class for screens in the setup assistant
-#include <ros/ros.h>
 
 namespace moveit_setup_assistant
 {

--- a/src/widgets/setup_assistant_widget.h
+++ b/src/widgets/setup_assistant_widget.h
@@ -59,11 +59,15 @@
 #include "virtual_joints_widget.h"
 #include "passive_joints_widget.h"
 #include "configuration_files_widget.h"
+
+#ifndef Q_MOC_RUN
 #include <moveit/setup_assistant/tools/moveit_config_data.h>
+
 // Other
 #include <ros/ros.h>
 #include <boost/program_options.hpp> // for parsing input arguments
 #include <boost/thread/mutex.hpp>
+#endif
 
 // Forward declarations
 namespace rviz

--- a/src/widgets/start_screen_widget.h
+++ b/src/widgets/start_screen_widget.h
@@ -42,9 +42,13 @@
 #include <QPushButton>
 #include <QLabel>
 #include <QProgressBar>
+
+#ifndef Q_MOC_RUN
 #include <urdf/model.h> // for testing a valid urdf is loaded
 #include <srdfdom/model.h> // for testing a valid srdf is loaded
 #include <moveit/setup_assistant/tools/moveit_config_data.h> // common datastructure class
+#endif
+
 #include "setup_screen_widget.h" // a base class for screens in the setup assistant
 
 

--- a/src/widgets/virtual_joints_widget.h
+++ b/src/widgets/virtual_joints_widget.h
@@ -47,8 +47,12 @@
 #include <QStackedLayout>
 #include <QString>
 #include <QComboBox>
+
 // SA
+#ifndef Q_MOC_RUN
 #include <moveit/setup_assistant/tools/moveit_config_data.h>
+#endif
+
 #include "header_widget.h"
 #include "setup_screen_widget.h" // a base class for screens in the setup assistant
 


### PR DESCRIPTION
I had the following error while trying to package this repository (`groovy-devel`) on Arch Linux:

``` sh
[ 51%] Generating src/widgets/moc_planning_groups_widget.cxx
Generating src/widgets/moc_double_list_widget.cxx
usr/include/boost/type_traits/detail/has_binary_operator.hp:50: Parse error at "BOOST_JOIN"
CMakeFiles/moveit_setup_assistant.dir/build.make:71: recipe for target 'src/widgets/moc_start_screen_widget.cxx' failed
```

Note that I use Boost 1.55. This is a [known bug](https://bugreports.qt-project.org/browse/QTBUG-22829) with Qt4. The patch that was recently pushed to `hydro-devel` also solves this problem on `groovy-devel`. 
