### PR TITLE
Prevent dirty transforms warning

### DIFF
--- a/src/widgets/robot_poses_widget.cpp
+++ b/src/widgets/robot_poses_widget.cpp
@@ -355,7 +355,6 @@ void RobotPosesWidget::showPose( srdf::Model::GroupState *pose )
   // Update the joints
   publishJoints();
 
-
   // Unhighlight all links
   Q_EMIT unhighlightAll();
 
@@ -855,6 +854,9 @@ void RobotPosesWidget::publishJoints()
 
   // Publish!
   pub_robot_state_.publish( msg );
+
+  // Prevent dirty collision body transforms
+  config_data_->getPlanningScene()->getCurrentStateNonConst().update();
 
   // Decide if current state is in collision
   collision_detection::CollisionResult result;


### PR DESCRIPTION
the robot state was not being updated before the collision checker was being called.

fix for moveit mailing list issue:
https://groups.google.com/forum/#!topic/moveit-users/5HZ9NjtSWOw
