### PR TITLE
Fixed bug 82 in a quick way by reducing min size.

### DIFF
--- a/src/setup_assistant_main.cpp
+++ b/src/setup_assistant_main.cpp
@@ -84,8 +84,8 @@ int main(int argc, char **argv)
 
   // Load Qt Widget
   moveit_setup_assistant::SetupAssistantWidget saw( NULL, vm );
-  saw.setMinimumWidth(1024);
-  saw.setMinimumHeight(768);
+  saw.setMinimumWidth(980);
+  saw.setMinimumHeight(700);
   //  saw.setWindowState( Qt::WindowMaximized );
 
   saw.show();


### PR DESCRIPTION
This is a quick fix for #82.

If Dave Coleman was at Willow Garage when he wrote this code, I can tell you he was using a 2560x1600 resolution screen.  So clearly he wasn't worried about fitting everything in compactly.

This change is just a quick patch to make things usable on a 768-vertical screen.  Better changes would involve reworking the layout of the main page.  There is lots of unnecessary space in there, but it is not filled by removing the min-size lines, it just squishes the widgets down and hides a bunch of information.
