### PR TITLE
use relative instead of absolute names for topics (to allow for namespaces)

### DIFF
--- a/templates/moveit_config_pkg_template/launch/moveit.rviz
+++ b/templates/moveit_config_pkg_template/launch/moveit.rviz
@@ -331,7 +331,7 @@ Visualization Manager:
         Show Robot Visual: true
         Show Trail: false
         State Display Time: 0.05 s
-        Trajectory Topic: /move_group/display_planned_path
+        Trajectory Topic: move_group/display_planned_path
       Planning Metrics:
         Payload: 1
         Show Joint Torques: false
@@ -350,7 +350,7 @@ Visualization Manager:
         Show Workspace: false
         Start State Alpha: 1
         Start State Color: 0; 255; 0
-      Planning Scene Topic: /move_group/monitored_planning_scene
+      Planning Scene Topic: move_group/monitored_planning_scene
       Robot Description: robot_description
       Scene Geometry:
         Scene Alpha: 1


### PR DESCRIPTION
trivial change related to
https://github.com/ros-planning/moveit_ros/pull/474
