### PR TITLE
Added a new 'velocity_scaling_factor' parameter to joint_limits.yaml

### DIFF
--- a/src/tools/moveit_config_data.cpp
+++ b/src/tools/moveit_config_data.cpp
@@ -540,6 +540,10 @@ bool MoveItConfigData::outputJointLimitsYAML( const std::string& file_path )
   emitter << YAML::Key << "joint_limits";
   emitter << YAML::Value << YAML::BeginMap;
 
+  // Set an optional velocity scaling factor, off by default
+  emitter << YAML::Key << "velocity_scaling_factor";
+  emitter << YAML::Value << 1.0;
+
   // Union all the joints in groups. Uses a custom comparator to allow the joints to be sorted by name
   std::set<const robot_model::JointModel*, joint_model_compare> joints;
 
@@ -604,7 +608,11 @@ bool MoveItConfigData::outputJointLimitsYAML( const std::string& file_path )
     ROS_ERROR_STREAM( "Unable to open file for writing " << file_path );
     return false;
   }
-
+  // Add documentation into joint_limits.yaml
+  output_stream << "# joint_limits.yaml allows the dynamics properties specified in the URDF to be overwritten or augmented as needed" << std::endl;
+  output_stream << "# Specific joint properties can be changed with the keys [max_position, min_position, max_velocity, max_acceleration]" << std::endl;
+  output_stream << "# Joint limits can be turned off with [has_velocity_limits, has_acceleration_limits]" << std::endl;
+  output_stream << "# Finally, as a final step velocity limits can be scaled using a global value [velocity_scaling_factor]" << std::endl;
   output_stream << emitter.c_str();
   output_stream.close();
 


### PR DESCRIPTION
This evenly reduces max joint velocity for all joints. It is particularly useful if you are using the default max_velocities from the URDF, but want to slow down your robot say by 10% (set it to 0.1)

Also, I added much needed documentation for how joint_limits.yaml works, inline.

As we discussed @mmurooka

PR follows https://github.com/ros-planning/moveit_ros/pull/486
