### PR TITLE
Debug and octomap improvements in launch file templtes

### DIFF
--- a/templates/moveit_config_pkg_template/launch/gdb_settings.gdb
+++ b/templates/moveit_config_pkg_template/launch/gdb_settings.gdb
@@ -1,0 +1,8 @@
+## This file allows developers to set breakpoints in the move_group.launch file
+## To set a breakpoint, compile with debug flag set to true. Add a line below with the source file name,
+## a colon, then the line number to break on. Then launch move_group with argument debug:=true
+
+set breakpoint pending on
+
+## Example break point:
+#break trajectory_execution_manager.cpp:228

--- a/templates/moveit_config_pkg_template/launch/move_group.launch
+++ b/templates/moveit_config_pkg_template/launch/move_group.launch
@@ -5,15 +5,16 @@
   <!-- GDB Debug Option -->
   <arg name="debug" default="false" />
   <arg unless="$(arg debug)" name="launch_prefix" value="" />
-  <arg     if="$(arg debug)" name="launch_prefix" value="gdb --ex run --args" />
+  <arg     if="$(arg debug)" name="launch_prefix"
+	   value="gdb -x $(find [GENERATED_PACKAGE_NAME])/launch/gdb_settings.gdb --ex run --args" />
 
   <!-- Verbose Mode Option -->
-  <arg name="info" default="$(arg debug)" />  
+  <arg name="info" default="$(arg debug)" />
   <arg unless="$(arg info)" name="command_args" value="" />
   <arg     if="$(arg info)" name="command_args" value="--debug" />
 
   <!-- move_group settings -->
-  <arg name="allow_trajectory_execution" default="true"/> 
+  <arg name="allow_trajectory_execution" default="true"/>
   <arg name="fake_execution" default="false"/>
   <arg name="max_safe_path_cost" default="1"/>
   <arg name="jiggle_fraction" default="0.05" />
@@ -33,7 +34,7 @@
 
   <!-- Sensors Functionality -->
   <include ns="move_group" file="$(find [GENERATED_PACKAGE_NAME])/launch/sensor_manager.launch.xml" if="$(arg allow_trajectory_execution)">
-    <arg name="moveit_sensor_manager" value="[ROBOT_NAME]" /> 
+    <arg name="moveit_sensor_manager" value="[ROBOT_NAME]" />
   </include>
 
   <!-- Start the actual move_group node/action server -->
@@ -55,6 +56,7 @@
 				      move_group/MoveGroupQueryPlannersService
 				      move_group/MoveGroupStateValidationService
 				      move_group/MoveGroupGetPlanningSceneService
+				      move_group/ClearOctomapService
 				      " />
 
     <!-- Publish the planning scene of the physical robot so that rviz plugin can know actual robot -->
@@ -63,5 +65,5 @@
     <param name="planning_scene_monitor/publish_state_updates" value="$(arg publish_monitored_planning_scene)" />
     <param name="planning_scene_monitor/publish_transforms_updates" value="$(arg publish_monitored_planning_scene)" />
   </node>
-  
+
 </launch>


### PR DESCRIPTION
- Added clear octomap service to move_group launch file template for https://github.com/ros-planning/moveit_ros/pull/495
- Added gdb debug helper that allows easier break point addition
- Removed trailiing whitespace

Only causes changes when someone re-runs the moveit_setup_assistant
