### PR TITLE
Shrink window height

### DIFF
--- a/src/setup_assistant_main.cpp
+++ b/src/setup_assistant_main.cpp
@@ -85,7 +85,7 @@ int main(int argc, char **argv)
   // Load Qt Widget
   moveit_setup_assistant::SetupAssistantWidget saw( NULL, vm );
   saw.setMinimumWidth(980);
-  saw.setMinimumHeight(700);
+  saw.setMinimumHeight(550);
   //  saw.setWindowState( Qt::WindowMaximized );
 
   saw.show();

--- a/src/widgets/start_screen_widget.cpp
+++ b/src/widgets/start_screen_widget.cpp
@@ -44,6 +44,7 @@
 #include <QApplication>
 #include <QFont>
 #include <QFileDialog>
+#include <QTextEdit>
 // ROS
 #include <ros/ros.h>
 #include <ros/package.h> // for getting file path for loadng images
@@ -872,11 +873,10 @@ SelectModeWidget::SelectModeWidget( QWidget* parent )
   layout->setAlignment( widget_title, Qt::AlignTop);
 
   // Widget Instructions
-  QLabel * widget_instructions = new QLabel(this);
+  QTextEdit * widget_instructions = new QTextEdit(this);
   widget_instructions->setText( "All settings for MoveIt are stored in a Moveit configuration package. Here you have the option to create a new configuration package, or load an existing one. Note: any changes to a MoveIt configuration package outside this setup assistant will likely be overwritten by this tool." );
-  widget_instructions->setWordWrap(true);
+  widget_instructions->setWordWrapMode(QTextOption::WrapAtWordBoundaryOrAnywhere);
   //widget_instructions->setMinimumWidth(1);
-  widget_instructions->setSizePolicy( QSizePolicy::Preferred, QSizePolicy::Preferred );
   layout->addWidget( widget_instructions);
   layout->setAlignment( widget_instructions, Qt::AlignTop);
 

--- a/src/widgets/start_screen_widget.cpp
+++ b/src/widgets/start_screen_widget.cpp
@@ -109,7 +109,7 @@ StartScreenWidget::StartScreenWidget( QWidget* parent, moveit_setup_assistant::M
 
   if (logo_image_->load( image_path.c_str() ))
   {
-    logo_image_label_->setPixmap(QPixmap::fromImage( *logo_image_));
+    logo_image_label_->setPixmap(QPixmap::fromImage(logo_image_->scaledToHeight(50)));
     logo_image_label_->setMinimumWidth(96);
   }
   else


### PR DESCRIPTION
On computers with smaller display size, the window of setup assistant is too large and the button hides beneath the desktop window. Although by moving into the WorkSpace below on Ubuntu the users still can hit the buttons, not all users can realize that option.

This PR does:
- changes minimum window height
- Make MoveIt! logo smaller to allow more free space
- set scrollable one of the text areas that can get squashed with the new minimum height

I can rebase commits if that's better.

Very first page (left: current, right: this PReq)
![moveit_setup_assis_fixedheight_1](https://cloud.githubusercontent.com/assets/1840401/6435760/b3dc79a8-c0e7-11e4-98f5-476f2f4800e6.png)![moveit_setup_assis_new_1](https://cloud.githubusercontent.com/assets/1840401/6435762/b73e76aa-c0e7-11e4-9867-dedcc9089fe6.png)

Here the load pane is gone invisible, but either option ("current" or "existing" package) must be chosen to move forward anyway IMO.

After a package is loaded:
![moveit_setup_assis_new_2](https://cloud.githubusercontent.com/assets/1840401/6435764/bc3bf6b4-c0e7-11e4-9cdd-d95f3d34d6cd.png)
