### PR TITLE
Added command-line SRDF updater

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,6 +113,9 @@ target_link_libraries(${PROJECT_NAME}
 
 add_executable(${PROJECT_NAME}_updater src/collisions_updater.cpp )
 target_link_libraries(${PROJECT_NAME}_updater ${PROJECT_NAME}_tools ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+set_target_properties(${PROJECT_NAME}_updater
+                      PROPERTIES OUTPUT_NAME collisions_updater
+                      PREFIX "")
 
 install(TARGETS ${PROJECT_NAME} ${PROJECT_NAME}_widgets ${PROJECT_NAME}_tools ${PROJECT_NAME}_updater
   LIBRARY DESTINATION lib

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,7 +110,10 @@ target_link_libraries(${PROJECT_NAME}
   ${PROJECT_NAME}_widgets ${PROJECT_NAME}_tools
   ${QT_LIBRARIES} ${catkin_LIBRARIES} ${Boost_LIBRARIES} log4cxx)
 
-install(TARGETS ${PROJECT_NAME} ${PROJECT_NAME}_widgets ${PROJECT_NAME}_tools
+add_executable(${PROJECT_NAME}_updater src/collisions_updater.cpp )
+target_link_libraries(${PROJECT_NAME}_updater ${PROJECT_NAME}_tools ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+
+install(TARGETS ${PROJECT_NAME} ${PROJECT_NAME}_widgets ${PROJECT_NAME}_tools ${PROJECT_NAME}_updater
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
 install(DIRECTORY include/ DESTINATION include)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,7 @@ qt4_wrap_cpp(moc_sources ${headers})
 # Tools Library
 add_library(${PROJECT_NAME}_tools
   src/tools/compute_default_collisions.cpp
+  src/tools/file_loader.cpp
   src/tools/moveit_config_data.cpp
   src/tools/srdf_writer.cpp
 )

--- a/include/moveit/setup_assistant/tools/file_loader.h
+++ b/include/moveit/setup_assistant/tools/file_loader.h
@@ -42,7 +42,6 @@
 
 namespace moveit_setup_assistant
 {
-
 /// detemine if given path points to a xacro file
 bool isXacroFile(const std::string& path);
 
@@ -50,11 +49,10 @@ bool isXacroFile(const std::string& path);
 bool loadFileToString(std::string& buffer, const std::string& path);
 
 /// run xacro with the given args on the file, return result in buffer
-bool loadXacroFileToString(std::string& buffer, const std::string& path, const std::vector<std::string> &xacro_args);
+bool loadXacroFileToString(std::string& buffer, const std::string& path, const std::vector<std::string>& xacro_args);
 
 /// helper that branches between loadFileToString() and loadXacroFileToString() based on result of isXacroFile()
-bool loadXmlFileToString(std::string& buffer, const std::string& path, const std::vector<std::string> &xacro_args);
-
+bool loadXmlFileToString(std::string& buffer, const std::string& path, const std::vector<std::string>& xacro_args);
 }
 
 #endif

--- a/include/moveit/setup_assistant/tools/file_loader.h
+++ b/include/moveit/setup_assistant/tools/file_loader.h
@@ -1,0 +1,60 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2015,Fraunhofer IPA
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Fraunhofer IPA nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Mathias Lüdtke */
+
+#ifndef MOVEIT_MOVEIT_SETUP_ASSISTANT_TOOLS_FILE_LOADER_
+#define MOVEIT_MOVEIT_SETUP_ASSISTANT_TOOLS_FILE_LOADER_
+
+#include <string>
+#include <vector>
+
+namespace moveit_setup_assistant
+{
+
+/// detemine if given path points to a xacro file
+bool isXacroFile(const std::string& path);
+
+/// load file from given path into buffer
+bool loadFileToString(std::string& buffer, const std::string& path);
+
+/// run xacro with the given args on the file, return result in buffer
+bool loadXacroFileToString(std::string& buffer, const std::string& path, const std::vector<std::string> &xacro_args);
+
+/// helper that branches between loadFileToString() and loadXacroFileToString() based on result of isXacroFile()
+bool loadXmlFileToString(std::string& buffer, const std::string& path, const std::vector<std::string> &xacro_args);
+
+}
+
+#endif

--- a/include/moveit/setup_assistant/tools/moveit_config_data.h
+++ b/include/moveit/setup_assistant/tools/moveit_config_data.h
@@ -43,6 +43,7 @@
 #include <moveit/setup_assistant/tools/srdf_writer.h> // for writing srdf data
 #include <moveit/planning_scene/planning_scene.h> // for getting kinematic model
 #include <moveit/collision_detection/collision_matrix.h> // for figuring out if robot is in collision
+#include <moveit/setup_assistant/tools/compute_default_collisions.h> // for LinkPairMap
 
 namespace moveit_setup_assistant
 {
@@ -223,6 +224,13 @@ public:
   bool outputJointLimitsYAML( const std::string& file_path );
   bool outputFakeControllersYAML( const std::string& file_path );
   
+  /**
+   * \brief Set list of collision link pairs in SRDF; sorted; with optional filter
+   * \param link_pairs list of collision link pairs
+   * \param skip_mask mask of shifted moveit_setup_assistant::DisabledReason values that will be skipped
+   */
+  void setCollisionLinkPairs(const moveit_setup_assistant::LinkPairMap &link_pairs, size_t skip_mask = 0);
+
   /**
    * \brief Decide the best two joints to be used for the projection evaluator
    * \param planning_group name of group to use

--- a/include/moveit/setup_assistant/tools/moveit_config_data.h
+++ b/include/moveit/setup_assistant/tools/moveit_config_data.h
@@ -246,6 +246,13 @@ public:
   bool inputKinematicsYAML( const std::string& file_path );
 
   /**
+   * Set package path; try to resolve path from package name if directory does not exist
+   * @param pkg_path path to package or package name
+   * @return bool if the path was set
+   */
+  bool setPackagePath( const std::string& pkg_path );
+
+  /**
    * Input .setup_assistant file - contains data used for the MoveIt Setup Assistant
    *
    * @param file_path path to .setup_assistant file

--- a/include/moveit/setup_assistant/tools/moveit_config_data.h
+++ b/include/moveit/setup_assistant/tools/moveit_config_data.h
@@ -253,6 +253,13 @@ public:
   bool setPackagePath( const std::string& pkg_path );
 
   /**
+   * Resolve path to .setup_assistant file
+   * @param path resolved path
+   * @return bool if the path could be resolved
+   */
+  bool getSetupAssistantYAMLPath( std::string& path );
+
+  /**
    * Input .setup_assistant file - contains data used for the MoveIt Setup Assistant
    *
    * @param file_path path to .setup_assistant file

--- a/include/moveit/setup_assistant/tools/moveit_config_data.h
+++ b/include/moveit/setup_assistant/tools/moveit_config_data.h
@@ -259,6 +259,12 @@ public:
    */
   bool getSetupAssistantYAMLPath( std::string& path );
 
+  /// Make the full URDF path using the loaded .setup_assistant data
+  bool createFullURDFPath();
+
+  /// Make the full SRDF path using the loaded .setup_assistant data
+  bool createFullSRDFPath( const std::string& package_path );
+
   /**
    * Input .setup_assistant file - contains data used for the MoveIt Setup Assistant
    *

--- a/src/collisions_updater.cpp
+++ b/src/collisions_updater.cpp
@@ -67,11 +67,10 @@ public:
 
         if(!config_data.setPackagePath(pkg_path))  return false;
 
-        fs::path setup_assistant_file = config_data.config_pkg_path_;
-        setup_assistant_file /= ".setup_assistant";
+        std::string setup_assistant_path;
+        if(!config_data.getSetupAssistantYAMLPath(setup_assistant_path)) return false;
 
-        if(!config_data.inputSetupAssistantYAML( setup_assistant_file.make_preferred().native().c_str() ) )
-            return false;
+        if(!config_data.inputSetupAssistantYAML(setup_assistant_path)) return false;
 
         fs::path urdf_path;
 

--- a/src/collisions_updater.cpp
+++ b/src/collisions_updater.cpp
@@ -42,151 +42,171 @@
 
 namespace po = boost::program_options;
 
-bool loadSetupAssistantConfig(moveit_setup_assistant::MoveItConfigData &config_data, const std::string &pkg_path){
+bool loadSetupAssistantConfig(moveit_setup_assistant::MoveItConfigData &config_data, const std::string &pkg_path)
+{
+  if (!config_data.setPackagePath(pkg_path))
+  {
+    ROS_ERROR_STREAM("Could not set package path '" << pkg_path << "'");
+    return false;
+  }
 
-    if(!config_data.setPackagePath(pkg_path)){
-        ROS_ERROR_STREAM("Could not set package path '" << pkg_path << "'");
-        return false;
-    }
+  std::string setup_assistant_path;
+  if (!config_data.getSetupAssistantYAMLPath(setup_assistant_path))
+  {
+    ROS_ERROR_STREAM("Could not resolve path to .setup_assistant");
+    return false;
+  }
 
-    std::string setup_assistant_path;
-    if(!config_data.getSetupAssistantYAMLPath(setup_assistant_path)){
-        ROS_ERROR_STREAM("Could not resolve path to .setup_assistant");
-        return false;
-    }
+  if (!config_data.inputSetupAssistantYAML(setup_assistant_path))
+  {
+    ROS_ERROR_STREAM("Could not parse .setup_assistant file from '" << setup_assistant_path << "'");
+    return false;
+  }
 
-    if(!config_data.inputSetupAssistantYAML(setup_assistant_path)){
-        ROS_ERROR_STREAM("Could not parse .setup_assistant file from '" << setup_assistant_path << "'");
-        return false;
-    }
+  config_data.createFullURDFPath();  // might fail at this point
 
-    config_data.createFullURDFPath(); // might fail at this point
+  config_data.createFullSRDFPath(config_data.config_pkg_path_);  // might fail at this point
 
-    config_data.createFullSRDFPath(config_data.config_pkg_path_); // might fail at this point
-
-    return true;
+  return true;
 }
 
-bool setup(moveit_setup_assistant::MoveItConfigData &config_data, bool keep_old, const std::vector<std::string> &xacro_args) {
-    std::string urdf_string;
-    if(!moveit_setup_assistant::loadXmlFileToString(urdf_string, config_data.urdf_path_, xacro_args)){
-        ROS_ERROR_STREAM("Could not load URDF from '" << config_data.urdf_path_ << "'");
-        return false;
-    }
-    if(!config_data.urdf_model_->initString( urdf_string)){
-        ROS_ERROR_STREAM("Could not parse URDF from '" << config_data.urdf_path_ << "'");
-        return false;
-    }
+bool setup(moveit_setup_assistant::MoveItConfigData &config_data, bool keep_old,
+           const std::vector<std::string> &xacro_args)
+{
+  std::string urdf_string;
+  if (!moveit_setup_assistant::loadXmlFileToString(urdf_string, config_data.urdf_path_, xacro_args))
+  {
+    ROS_ERROR_STREAM("Could not load URDF from '" << config_data.urdf_path_ << "'");
+    return false;
+  }
+  if (!config_data.urdf_model_->initString(urdf_string))
+  {
+    ROS_ERROR_STREAM("Could not parse URDF from '" << config_data.urdf_path_ << "'");
+    return false;
+  }
 
-    std::string srdf_string;
-    if(!moveit_setup_assistant::loadXmlFileToString(srdf_string, config_data.srdf_path_, xacro_args)){
-        ROS_ERROR_STREAM("Could not load SRDF from '" << config_data.srdf_path_ << "'");
-        return false;
-    }
-    if(!config_data.srdf_->initString( *config_data.urdf_model_, srdf_string)){
-        ROS_ERROR_STREAM("Could not parse SRDF from '" << config_data.srdf_path_ << "'");
-        return false;
-    }
+  std::string srdf_string;
+  if (!moveit_setup_assistant::loadXmlFileToString(srdf_string, config_data.srdf_path_, xacro_args))
+  {
+    ROS_ERROR_STREAM("Could not load SRDF from '" << config_data.srdf_path_ << "'");
+    return false;
+  }
+  if (!config_data.srdf_->initString(*config_data.urdf_model_, srdf_string))
+  {
+    ROS_ERROR_STREAM("Could not parse SRDF from '" << config_data.srdf_path_ << "'");
+    return false;
+  }
 
+  if (!keep_old)
+    config_data.srdf_->disabled_collisions_.clear();
 
-    if(!keep_old) config_data.srdf_->disabled_collisions_.clear();
-
-    return true;
+  return true;
 }
 
-moveit_setup_assistant::LinkPairMap compute(moveit_setup_assistant::MoveItConfigData &config_data,
-                                            uint32_t trials, double min_collision_fraction,  bool verbose){
-    // TODO: spin thread and print progess if verbose
-    unsigned int collision_progress;
-    return moveit_setup_assistant::computeDefaultCollisions(config_data.getPlanningScene(),
-                                                            &collision_progress,
-                                                            trials > 0,
-                                                            trials,
-                                                            min_collision_fraction, verbose);
+moveit_setup_assistant::LinkPairMap compute(moveit_setup_assistant::MoveItConfigData &config_data, uint32_t trials,
+                                            double min_collision_fraction, bool verbose)
+{
+  // TODO: spin thread and print progess if verbose
+  unsigned int collision_progress;
+  return moveit_setup_assistant::computeDefaultCollisions(config_data.getPlanningScene(), &collision_progress,
+                                                          trials > 0, trials, min_collision_fraction, verbose);
 }
 
-int main(int argc, char * argv[]){
+int main(int argc, char *argv[])
+{
+  std::string config_pkg_path;
+  std::string urdf_path;
+  std::string srdf_path;
 
-    std::string config_pkg_path;
-    std::string urdf_path;
-    std::string srdf_path;
+  std::string output_path;
 
-    std::string output_path;
+  bool include_default = false, include_always = false, keep_old = false, verbose = false;
 
-    bool include_default = false, include_always = false, keep_old = false, verbose = false;
+  double min_collision_fraction = 1.0;
 
-    double min_collision_fraction = 1.0;
+  uint32_t never_trials = 0;
 
-    uint32_t never_trials = 0;
+  po::options_description desc("Allowed options");
+  desc.add_options()
+    ("help", "show help")
+    ("config-pkg", po::value(&config_pkg_path), "path to moveit config package")
+    ("urdf", po::value(&urdf_path), "path to URDF ( or xacro)")
+    ("srdf", po::value(&srdf_path), "path to SRDF ( or xacro)")
+    ("output", po::value(&output_path), "output path for SRDF")
 
-    po::options_description desc("Allowed options");
-    desc.add_options()
-        ("help", "show help")
-        ("config-pkg", po::value(&config_pkg_path), "path to moveit config package")
-        ("urdf", po::value(&urdf_path), "path to URDF ( or xacro)")
-        ("srdf", po::value(&srdf_path), "path to SRDF ( or xacro)")
-        ("output", po::value(&output_path), "output path for SRDF")
+    ("xacro-args", po::value<std::vector<std::string> >()->composing(), "additional arguments for xacro")
 
-        ("xacro-args", po::value<std::vector<std::string> >()->composing(), "additional arguments for xacro")
+    ("default", po::bool_switch(&include_default),  "disable default colliding pairs")
+    ("always", po::bool_switch(&include_always),  "disable always colliding pairs")
 
-        ("default", po::bool_switch(&include_default),  "disable default colliding pairs")
-        ("always", po::bool_switch(&include_always),  "disable always colliding pairs")
+    ("keep", po::bool_switch(&keep_old),  "keep disabled link from SRDF")
+    ("verbose", po::bool_switch(&verbose),  "verbose output")
 
-        ("keep", po::bool_switch(&keep_old),  "keep disabled link from SRDF")
-        ("verbose", po::bool_switch(&verbose),  "verbose output")
+    ("trials", po::value(&never_trials),  "number of trials for searching never colliding pairs")
+    ("min-collision-fraction", po::value(&min_collision_fraction),  "fraction of small sample size to determine links that are alwas colliding")
+  ;
 
-        ("trials", po::value(&never_trials),  "number of trials for searching never colliding pairs")
-        ("min-collision-fraction", po::value(&min_collision_fraction),  "fraction of small sample size to determine links that are alwas colliding")
-      ;
+  po::positional_options_description pos_desc;
+  pos_desc.add("xacro-args", -1);
 
-    po::positional_options_description pos_desc;
-    pos_desc.add("xacro-args", -1);
+  po::variables_map vm;
+  po::store(po::command_line_parser(argc, argv).options(desc).positional(pos_desc).run(), vm);
+  po::notify(vm);
 
-    po::variables_map vm;
-    po::store(po::command_line_parser(argc, argv).options(desc).positional(pos_desc).run(), vm);
-    po::notify(vm);
+  if (vm.count("help"))
+  {
+    std::cout << desc << std::endl;
+    return 1;
+  }
 
-    if (vm.count("help")) {
-        std::cout << desc << std::endl;
-        return 1;
+  moveit_setup_assistant::MoveItConfigData config_data;
+
+  if (!config_pkg_path.empty())
+  {
+    if (!loadSetupAssistantConfig(config_data, config_pkg_path))
+    {
+      ROS_ERROR_STREAM("Could not load config at '" << config_pkg_path << "'");
+      return 1;
     }
+  }
+  else if (urdf_path.empty() || srdf_path.empty())
+  {
+    ROS_ERROR_STREAM("Please provide config package or URDF and SRDF path");
+    return 1;
+  }
+  else if (moveit_setup_assistant::isXacroFile(srdf_path) && output_path.empty())
+  {
+    ROS_ERROR_STREAM("Please provide a different output file for SRDF xacro input file");
+    return 1;
+  }
 
-    moveit_setup_assistant::MoveItConfigData config_data;
+  // overwrite config paths if applicable
+  if (!urdf_path.empty())
+    config_data.urdf_path_ = urdf_path;
+  if (!srdf_path.empty())
+    config_data.srdf_path_ = srdf_path;
 
-    if(!config_pkg_path.empty()){
-        if(!loadSetupAssistantConfig(config_data, config_pkg_path)){
-            ROS_ERROR_STREAM("Could not load config at '" << config_pkg_path << "'");
-            return 1;
-        }
-    }else if (urdf_path.empty() || srdf_path.empty()){
-        ROS_ERROR_STREAM("Please provide config package or URDF and SRDF path");
-        return 1;
-    }else if(moveit_setup_assistant::isXacroFile(srdf_path) && output_path.empty()){
-        ROS_ERROR_STREAM("Please provide a different output file for SRDF xacro input file");
-        return 1;
-    }
+  std::vector<std::string> xacro_args;
+  if (vm.count("xacro-args"))
+    xacro_args = vm["xacro-args"].as<std::vector<std::string> >();
 
-    // overwrite config paths if applicable
-    if(!urdf_path.empty()) config_data.urdf_path_ = urdf_path;
-    if(!srdf_path.empty()) config_data.srdf_path_ = srdf_path;
+  if (!setup(config_data, keep_old, xacro_args))
+  {
+    ROS_ERROR_STREAM("Could not setup updater");
+    return 1;
+  }
 
-    std::vector<std::string> xacro_args;
-    if(vm.count("xacro-args")) xacro_args = vm["xacro-args"].as<std::vector<std::string> >();
+  moveit_setup_assistant::LinkPairMap link_pairs = compute(config_data, never_trials, min_collision_fraction, verbose);
 
-    if(!setup(config_data, keep_old, xacro_args)){
-        ROS_ERROR_STREAM("Could not setup updater");
-        return 1;
-    }
+  size_t skip_mask = 0;
+  if (!include_default)
+    skip_mask |= (1 << moveit_setup_assistant::DEFAULT);
+  if (!include_always)
+    skip_mask |= (1 << moveit_setup_assistant::ALWAYS);
 
-    moveit_setup_assistant::LinkPairMap link_pairs = compute(config_data, never_trials, min_collision_fraction,verbose);
+  config_data.setCollisionLinkPairs(link_pairs, skip_mask);
 
-    size_t skip_mask = 0;
-    if(!include_default) skip_mask |= (1<<moveit_setup_assistant::DEFAULT);
-    if(!include_always) skip_mask |= (1<<moveit_setup_assistant::ALWAYS);
+  config_data.srdf_->writeSRDF(output_path.empty() ? config_data.srdf_path_ : output_path);
 
-    config_data.setCollisionLinkPairs(link_pairs, skip_mask);
-
-    config_data.srdf_->writeSRDF(output_path.empty() ? config_data.srdf_path_ : output_path );
-
-    return 0;
+  return 0;
 }

--- a/src/collisions_updater.cpp
+++ b/src/collisions_updater.cpp
@@ -1,3 +1,38 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2015, Fraunhofer IPA
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Fraunhofer IPA nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Mathias Lüdtke */
 #include <ros/ros.h>
 #include <ros/package.h> // for getting file path for loadng images
 

--- a/src/collisions_updater.cpp
+++ b/src/collisions_updater.cpp
@@ -72,21 +72,9 @@ public:
 
         if(!config_data.inputSetupAssistantYAML(setup_assistant_path)) return false;
 
-        fs::path urdf_path;
+        config_data.createFullURDFPath(); // might fail at this point
 
-        if( config_data.urdf_pkg_name_.empty() || config_data.urdf_pkg_name_ == "\"\"" ){
-            urdf_path = config_data.urdf_pkg_relative_path_;
-        }else{
-            fs::path robot_desc_pkg_path = ros::package::getPath( config_data.urdf_pkg_name_ );
-            if( robot_desc_pkg_path.empty() ) return false;
-
-            urdf_path = robot_desc_pkg_path / config_data.urdf_pkg_relative_path_;
-        }
-        config_data.urdf_path_ = urdf_path.make_preferred().native();
-
-        fs::path srdf_path = config_data.config_pkg_path_ ;
-        srdf_path /= config_data.srdf_pkg_relative_path_;
-        config_data.srdf_path_ = srdf_path.make_preferred().native();
+        config_data.createFullSRDFPath(config_data.config_pkg_path_); // might fail at this point
 
         return true;
     }

--- a/src/collisions_updater.cpp
+++ b/src/collisions_updater.cpp
@@ -63,8 +63,9 @@ bool loadXmlFileToString(std::string& buffer, const std::string& path, const std
 class CollisionUpdater{
     moveit_setup_assistant::MoveItConfigData config_data;
 public:
-    bool loadSetupAssistantConfig(const std::string &path){
-        config_data.config_pkg_path_ = path;
+    bool loadSetupAssistantConfig(const std::string &pkg_path){
+
+        if(!config_data.setPackagePath(pkg_path))  return false;
 
         fs::path setup_assistant_file = config_data.config_pkg_path_;
         setup_assistant_file /= ".setup_assistant";

--- a/src/collisions_updater.cpp
+++ b/src/collisions_updater.cpp
@@ -220,8 +220,11 @@ int main(int argc, char * argv[]){
             return 1;
         }
     }else if (urdf_path.empty() || srdf_path.empty()){
-            std::cerr << "Please provide config package or URDF and SRDF path" << std::endl;
-            return 1;
+        std::cerr << "Please provide config package or URDF and SRDF path" << std::endl;
+        return 1;
+    }else if(isXacroFile(srdf_path) && output_path.empty()){
+        std::cerr << "Please provide a different output file for SRDF xacro input file" << std::endl;
+        return 1;
     }
 
     updater.setURDF(urdf_path);

--- a/src/collisions_updater.cpp
+++ b/src/collisions_updater.cpp
@@ -1,0 +1,213 @@
+#include <ros/ros.h>
+#include <ros/package.h> // for getting file path for loadng images
+
+#include <moveit/setup_assistant/tools/compute_default_collisions.h>
+#include <moveit/setup_assistant/tools/moveit_config_data.h>
+
+#include <boost/filesystem.hpp>  // for reading folders/files
+#include <boost/program_options.hpp>
+#include <boost/algorithm/string/join.hpp>
+
+#include <fstream>  // for reading in urdf
+#include <streambuf>
+
+namespace fs = boost::filesystem;
+namespace po = boost::program_options;
+
+bool loadFileToString(std::string& buffer, const std::string& path, const std::vector<std::string> &xacro_args){
+
+  if(path.find(".xacro") != std::string::npos){
+        std::string cmd = "rosrun xacro xacro ";
+        for(std::vector<std::string>::const_iterator it = xacro_args.begin(); it != xacro_args.end(); ++it)
+            cmd += *it + " ";
+        cmd += path;
+
+        FILE* pipe = popen(cmd.c_str(), "r");
+        if (!pipe) return false;
+
+        char pipe_buffer[128];
+        while(!feof(pipe)){
+            if(fgets(pipe_buffer, 128, pipe) != NULL)
+                    buffer += pipe_buffer;
+        }
+        pclose(pipe);
+  }else{
+    std::ifstream stream( path.c_str() );
+    if( !stream.good()) return false;
+
+    // Load the file to a string using an efficient memory allocation technique
+    stream.seekg(0, std::ios::end);
+    buffer.reserve(stream.tellg());
+    stream.seekg(0, std::ios::beg);
+    buffer.assign( (std::istreambuf_iterator<char>(stream)), std::istreambuf_iterator<char>() );
+    stream.close();
+  }
+  return true;
+}
+
+class CollisionUpdater{
+    moveit_setup_assistant::MoveItConfigData config_data;
+public:
+    bool loadSetupAssistantConfig(const std::string &path){
+        config_data.config_pkg_path_ = path;
+
+        fs::path setup_assistant_file = config_data.config_pkg_path_;
+        setup_assistant_file /= ".setup_assistant";
+
+        if(!config_data.inputSetupAssistantYAML( setup_assistant_file.make_preferred().native().c_str() ) )
+            return false;
+
+        fs::path urdf_path;
+
+        if( config_data.urdf_pkg_name_.empty() || config_data.urdf_pkg_name_ == "\"\"" ){
+            urdf_path = config_data.urdf_pkg_relative_path_;
+        }else{
+            fs::path robot_desc_pkg_path = ros::package::getPath( config_data.urdf_pkg_name_ );
+            if( robot_desc_pkg_path.empty() ) return false;
+
+            urdf_path = robot_desc_pkg_path / config_data.urdf_pkg_relative_path_;
+        }
+        config_data.urdf_path_ = urdf_path.make_preferred().native();
+
+        fs::path srdf_path = config_data.config_pkg_path_ ;
+        srdf_path /= config_data.srdf_pkg_relative_path_;
+        config_data.srdf_path_ = srdf_path.make_preferred().native();
+
+        return true;
+    }
+
+    void setURDF(const std::string &path) {
+        if(!path.empty()) config_data.urdf_path_ = path;
+    }
+    void setSRDF(const std::string &path) {
+        if(!path.empty()) config_data.srdf_path_ = path;
+    }
+
+    bool setup(bool keep_old, const std::vector<std::string> &xacro_args){
+        std::string urdf_string;
+        if(config_data.urdf_path_.empty() || !loadFileToString(urdf_string, config_data.urdf_path_, xacro_args)) return false;
+        if(!config_data.urdf_model_->initString( urdf_string))return false;
+
+        std::string srdf_string;
+        if(config_data.srdf_path_.empty() || !loadFileToString(srdf_string, config_data.srdf_path_, xacro_args)) return false;
+        if(!config_data.srdf_->initString( *config_data.urdf_model_, srdf_string)) return false;
+
+
+        if(!keep_old) config_data.srdf_->disabled_collisions_.clear();
+
+        return true;
+    }
+
+    moveit_setup_assistant::LinkPairMap compute(uint32_t trials, double min_collision_fraction,  bool verbose){
+        unsigned int collision_progress;
+        return moveit_setup_assistant::computeDefaultCollisions(config_data.getPlanningScene(),
+                                                                &collision_progress,
+                                                                trials > 0,
+                                                                trials,
+                                                                min_collision_fraction, verbose);
+    }
+
+    void write(const moveit_setup_assistant::LinkPairMap &link_pairs, bool include_default, bool include_always, const std::string &output_path){
+        // Create temp disabled collision
+        srdf::Model::DisabledCollision dc;
+
+        // copy the data in this class's LinkPairMap datastructure to srdf::Model::DisabledCollision format
+        for ( moveit_setup_assistant::LinkPairMap::const_iterator pair_it = link_pairs.begin();
+                pair_it != link_pairs.end(); ++pair_it)
+        {
+            // Only copy those that are actually disabled
+            if( pair_it->second.disable_check ){
+                if( pair_it->second.reason == moveit_setup_assistant::DEFAULT && !include_default) continue;
+                if( pair_it->second.reason == moveit_setup_assistant::ALWAYS && !include_always) continue;
+                dc.link1_ = pair_it->first.first;
+                dc.link2_ = pair_it->first.second;
+                dc.reason_ = moveit_setup_assistant::disabledReasonToString( pair_it->second.reason );
+                config_data.srdf_->disabled_collisions_.push_back( dc );
+            }
+        }
+
+        // Update collision_matrix for robot pose's use
+        config_data.loadAllowedCollisionMatrix();
+
+        config_data.srdf_->writeSRDF(output_path.empty() ? config_data.srdf_path_ : output_path );
+
+    }
+
+};
+
+int main(int argc, char * argv[]){
+
+    std::string config_pkg_path;
+    std::string urdf_path;
+    std::string srdf_path;
+
+    std::string output_path;
+
+    bool include_default = false, include_always = false, keep_old = false, verbose = false;
+
+    double min_collision_fraction = 1.0;
+
+    uint32_t never_trials = 0;
+
+    po::options_description desc("Allowed options");
+    desc.add_options()
+        ("help", "show help")
+        ("config-pkg", po::value(&config_pkg_path), "path to moveit config package")
+        ("urdf", po::value(&urdf_path), "path to URDF ( or xacro)")
+        ("srdf", po::value(&srdf_path), "path to SRDF ( or xacro)")
+        ("output", po::value(&output_path), "output path for SRDF")
+
+        ("xacro-args", po::value<std::vector<std::string> >()->composing(), "additional arguments for xacro")
+
+        ("default", po::bool_switch(&include_default),  "disable default colliding pairs")
+        ("always", po::bool_switch(&include_always),  "disable always colliding pairs")
+
+        ("keep", po::bool_switch(&keep_old),  "keep disabled link from SRDF")
+        ("verbose", po::bool_switch(&verbose),  "verbose output")
+
+        ("trials", po::value(&never_trials),  "number of trials for searching never colliding pairs")
+        ("min-collision-fraction", po::value(&min_collision_fraction),  "fraction of small sample size to determine links that are alwas colliding")
+      ;
+
+    po::positional_options_description pos_desc;
+    pos_desc.add("xacro-args", -1);
+
+    po::variables_map vm;
+    po::store(po::command_line_parser(argc, argv).options(desc).positional(pos_desc).run(), vm);
+    po::notify(vm);
+
+    if (vm.count("help")) {
+        std::cout << desc << std::endl;
+        return 1;
+    }
+
+    CollisionUpdater updater;
+
+    if(!config_pkg_path.empty()){
+        if(!updater.loadSetupAssistantConfig(config_pkg_path)){
+            std::cerr << "Could not load config at '" << config_pkg_path << "'" << std::endl;
+            return 1;
+        }
+    }else if (urdf_path.empty() || srdf_path.empty()){
+            std::cerr << "Please provide config package or URDF and SRDF path" << std::endl;
+            return 1;
+    }
+
+    updater.setURDF(urdf_path);
+    updater.setSRDF(srdf_path);
+
+    std::vector<std::string> xacro_args;
+    if(vm.count("xacro-args")) xacro_args = vm["xacro-args"].as<std::vector<std::string> >();
+
+    if(!updater.setup(keep_old, xacro_args)){
+        std::cerr << "Could not setup updater" << std::endl;
+        return 1;
+    }
+
+    moveit_setup_assistant::LinkPairMap link_pairs = updater.compute(never_trials, min_collision_fraction,verbose);
+
+    updater.write(link_pairs, include_default, include_always, output_path);
+
+
+    return 0;
+}

--- a/src/tools/file_loader.cpp
+++ b/src/tools/file_loader.cpp
@@ -39,55 +39,67 @@
 #include <fstream>
 #include <streambuf>
 
-
 namespace moveit_setup_assistant
 {
-
-bool isXacroFile(const std::string& path) { return path.find(".xacro") != std::string::npos; } // TODO: implement case-insensitive search
-
-bool loadFileToString(std::string& buffer, const std::string& path){
-    if(path.empty()) return false;
-
-    std::ifstream stream( path.c_str() );
-    if( !stream.good()) return false;
-
-    // Load the file to a string using an efficient memory allocation technique
-    stream.seekg(0, std::ios::end);
-    buffer.reserve(stream.tellg());
-    stream.seekg(0, std::ios::beg);
-    buffer.assign( (std::istreambuf_iterator<char>(stream)), std::istreambuf_iterator<char>() );
-    stream.close();
-
-    return true;
+bool isXacroFile(const std::string& path)
+{
+  // TODO: implement case-insensitive search
+  return path.find(".xacro") != std::string::npos;
 }
 
-bool loadXacroFileToString(std::string& buffer, const std::string& path, const std::vector<std::string> &xacro_args){
-    if(path.empty()) return false;
+bool loadFileToString(std::string& buffer, const std::string& path)
+{
+  if (path.empty())
+    return false;
 
-    std::string cmd = "rosrun xacro xacro ";
-    for(std::vector<std::string>::const_iterator it = xacro_args.begin(); it != xacro_args.end(); ++it)
-        cmd += *it + " ";
-    cmd += path;
+  std::ifstream stream(path.c_str());
+  if (!stream.good())
+    return false;
 
-    FILE* pipe = popen(cmd.c_str(), "r");
-    if (!pipe) return false;
+  // Load the file to a string using an efficient memory allocation technique
+  stream.seekg(0, std::ios::end);
+  buffer.reserve(stream.tellg());
+  stream.seekg(0, std::ios::beg);
+  buffer.assign((std::istreambuf_iterator<char>(stream)), std::istreambuf_iterator<char>());
+  stream.close();
 
-    char pipe_buffer[128];
-    while(!feof(pipe)){
-        if(fgets(pipe_buffer, 128, pipe) != NULL)
-                buffer += pipe_buffer;
-    }
-    pclose(pipe);
-
-    return true;
+  return true;
 }
 
-bool loadXmlFileToString(std::string& buffer, const std::string& path, const std::vector<std::string> &xacro_args){
-    if(isXacroFile(path)){
-        return loadXacroFileToString(buffer, path, xacro_args);
-    }else{
-        return loadFileToString(buffer, path);
-    }
+bool loadXacroFileToString(std::string& buffer, const std::string& path, const std::vector<std::string>& xacro_args)
+{
+  if (path.empty())
+    return false;
+
+  std::string cmd = "rosrun xacro xacro ";
+  for (std::vector<std::string>::const_iterator it = xacro_args.begin(); it != xacro_args.end(); ++it)
+    cmd += *it + " ";
+  cmd += path;
+
+  FILE* pipe = popen(cmd.c_str(), "r");
+  if (!pipe)
+    return false;
+
+  char pipe_buffer[128];
+  while (!feof(pipe))
+  {
+    if (fgets(pipe_buffer, 128, pipe) != NULL)
+      buffer += pipe_buffer;
+  }
+  pclose(pipe);
+
+  return true;
 }
 
+bool loadXmlFileToString(std::string& buffer, const std::string& path, const std::vector<std::string>& xacro_args)
+{
+  if (isXacroFile(path))
+  {
+    return loadXacroFileToString(buffer, path, xacro_args);
+  }
+  else
+  {
+    return loadFileToString(buffer, path);
+  }
+}
 }

--- a/src/tools/file_loader.cpp
+++ b/src/tools/file_loader.cpp
@@ -1,0 +1,93 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2015,Fraunhofer IPA
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Fraunhofer IPA nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Mathias Lüdtke */
+
+#include <moveit/setup_assistant/tools/file_loader.h>
+
+#include <fstream>
+#include <streambuf>
+
+
+namespace moveit_setup_assistant
+{
+
+bool isXacroFile(const std::string& path) { return path.find(".xacro") != std::string::npos; } // TODO: implement case-insensitive search
+
+bool loadFileToString(std::string& buffer, const std::string& path){
+    if(path.empty()) return false;
+
+    std::ifstream stream( path.c_str() );
+    if( !stream.good()) return false;
+
+    // Load the file to a string using an efficient memory allocation technique
+    stream.seekg(0, std::ios::end);
+    buffer.reserve(stream.tellg());
+    stream.seekg(0, std::ios::beg);
+    buffer.assign( (std::istreambuf_iterator<char>(stream)), std::istreambuf_iterator<char>() );
+    stream.close();
+
+    return true;
+}
+
+bool loadXacroFileToString(std::string& buffer, const std::string& path, const std::vector<std::string> &xacro_args){
+    if(path.empty()) return false;
+
+    std::string cmd = "rosrun xacro xacro ";
+    for(std::vector<std::string>::const_iterator it = xacro_args.begin(); it != xacro_args.end(); ++it)
+        cmd += *it + " ";
+    cmd += path;
+
+    FILE* pipe = popen(cmd.c_str(), "r");
+    if (!pipe) return false;
+
+    char pipe_buffer[128];
+    while(!feof(pipe)){
+        if(fgets(pipe_buffer, 128, pipe) != NULL)
+                buffer += pipe_buffer;
+    }
+    pclose(pipe);
+
+    return true;
+}
+
+bool loadXmlFileToString(std::string& buffer, const std::string& path, const std::vector<std::string> &xacro_args){
+    if(isXacroFile(path)){
+        return loadXacroFileToString(buffer, path, xacro_args);
+    }else{
+        return loadFileToString(buffer, path);
+    }
+}
+
+}

--- a/src/tools/moveit_config_data.cpp
+++ b/src/tools/moveit_config_data.cpp
@@ -846,7 +846,46 @@ bool MoveItConfigData::getSetupAssistantYAMLPath( std::string& path )
   return fs::is_regular_file( path );
 }
 
-  return true;
+// ******************************************************************************************
+// Make the full URDF path using the loaded .setup_assistant data
+// ******************************************************************************************
+bool MoveItConfigData::createFullURDFPath()
+{
+  boost::trim(urdf_pkg_name_);
+
+  // Check if a package name was provided
+  if( urdf_pkg_name_.empty() || urdf_pkg_name_ == "\"\"" )
+  {
+    urdf_path_ = urdf_pkg_relative_path_;
+    urdf_pkg_name_.clear();
+  }
+  else
+  {
+    // Check that ROS can find the package
+    std::string robot_desc_pkg_path = ros::package::getPath( urdf_pkg_name_ );
+
+    if( robot_desc_pkg_path.empty() )
+    {
+      urdf_path_.clear();
+      return false;
+    }
+
+    // Append the relative URDF url path
+    urdf_path_ = appendPaths(robot_desc_pkg_path, urdf_pkg_relative_path_);
+  }
+
+  // Check that this file exits -------------------------------------------------
+  return fs::is_regular_file( urdf_path_ );
+}
+
+// ******************************************************************************************
+// Make the full SRDF path using the loaded .setup_assistant data
+// ******************************************************************************************
+bool MoveItConfigData::createFullSRDFPath( const std::string& package_path )
+{
+  srdf_path_ = appendPaths(package_path, srdf_pkg_relative_path_);
+
+  return fs::is_regular_file( srdf_path_ );
 }
 
 

--- a/src/tools/moveit_config_data.cpp
+++ b/src/tools/moveit_config_data.cpp
@@ -805,6 +805,35 @@ bool MoveItConfigData::inputKinematicsYAML( const std::string& file_path )
   return true; // file created successfully
 }
 
+
+// ******************************************************************************************
+// Set package path; try to resolve path from package name if directory does not exist
+// ******************************************************************************************
+bool MoveItConfigData::setPackagePath( const std::string& pkg_path )
+{
+  std::string full_package_path;
+
+  // check that the folder exists
+  if( !fs::is_directory( pkg_path ) )
+  {
+    // does not exist, check if its a package
+    full_package_path = ros::package::getPath( pkg_path );
+
+    // check that the folder exists
+    if( !fs::is_directory( full_package_path ) )
+    {
+      return false;
+    }
+  }
+  else
+  {
+    // they inputted a full path
+    full_package_path = pkg_path;
+  }
+
+  config_pkg_path_ = full_package_path;
+}
+
 // ******************************************************************************************
 // Input .setup_assistant file - contains data used for the MoveIt Setup Assistant
 // ******************************************************************************************

--- a/src/tools/moveit_config_data.cpp
+++ b/src/tools/moveit_config_data.cpp
@@ -835,6 +835,22 @@ bool MoveItConfigData::setPackagePath( const std::string& pkg_path )
 }
 
 // ******************************************************************************************
+// Resolve path to .setup_assistant file
+// ******************************************************************************************
+
+bool MoveItConfigData::getSetupAssistantYAMLPath( std::string& path )
+{
+  path = appendPaths(config_pkg_path_, ".setup_assistant");
+
+  // Check if the old package is a setup assistant package
+  return fs::is_regular_file( path );
+}
+
+  return true;
+}
+
+
+// ******************************************************************************************
 // Input .setup_assistant file - contains data used for the MoveIt Setup Assistant
 // ******************************************************************************************
 bool MoveItConfigData::inputSetupAssistantYAML( const std::string& file_path )

--- a/src/widgets/start_screen_widget.cpp
+++ b/src/widgets/start_screen_widget.cpp
@@ -728,45 +728,29 @@ bool StartScreenWidget::extractPackageNameFromPath()
 // ******************************************************************************************
 bool StartScreenWidget::createFullURDFPath()
 {
-  fs::path urdf_path;
-
-  // Check if a package name was provided
-  if( config_data_->urdf_pkg_name_.empty() || config_data_->urdf_pkg_name_ == "\"\"" )
+  if( !config_data_->createFullURDFPath() )
   {
-    urdf_path = config_data_->urdf_pkg_relative_path_;
-    ROS_WARN("The URDF path is absolute to the filesystem and not relative to a ROS package/stack");
-  }
-  else
-  {
-
-    // Check that ROS can find the package
-    fs::path robot_desc_pkg_path = ros::package::getPath( config_data_->urdf_pkg_name_ );
-
-    if( robot_desc_pkg_path.empty() )
+    if( config_data_->urdf_path_.empty() ) // no path could be resolved
     {
       QMessageBox::warning( this, "Error Loading Files", QString("ROS was unable to find the package name '")
                             .append( config_data_->urdf_pkg_name_.c_str() )
                             .append("'. Verify this package is inside your ROS workspace and is a proper ROS package.") );
-      return false;
     }
-
-    // Append the relative URDF url path
-    urdf_path = robot_desc_pkg_path;
-    urdf_path /= config_data_->urdf_pkg_relative_path_;
-  }
-
-
-  // Check that this file exits -------------------------------------------------
-  if( ! fs::is_regular_file( urdf_path ) )
-  {
-    QMessageBox::warning( this, "Error Loading Files",
-                          QString( "Unable to locate the URDF file in package. File: " )
-                          .append( urdf_path.make_preferred().native().c_str() ) );
+    else
+    {
+      QMessageBox::warning( this, "Error Loading Files",
+                            QString( "Unable to locate the URDF file in package. File: " )
+                            .append( config_data_->urdf_path_.c_str() ) );
+    }
     return false;
   }
+  fs::path urdf_path;
 
-  // Remember the path
-  config_data_->urdf_path_ = urdf_path.make_preferred().native();
+  // Check if a package name was provided
+  if( config_data_->urdf_pkg_name_.empty())
+  {
+    ROS_WARN("The URDF path is absolute to the filesystem and not relative to a ROS package/stack");
+  }
 
   return true; // success
 }
@@ -776,13 +760,7 @@ bool StartScreenWidget::createFullURDFPath()
 // ******************************************************************************************
 bool StartScreenWidget::createFullSRDFPath( const std::string& package_path )
 {
-  // Append the relative SRDF url path
-  fs::path srdf_path = package_path;
-  srdf_path /= config_data_->srdf_pkg_relative_path_;
-  config_data_->srdf_path_ = srdf_path.make_preferred().native();
-
-  // Check that this file exits
-  if( ! fs::is_regular_file( config_data_->srdf_path_ ) )
+  if( ! config_data_->createFullSRDFPath(package_path) )
   {
     QMessageBox::warning( this, "Error Loading Files",
                           QString("Unable to locate the SRDF file: " )

--- a/src/widgets/start_screen_widget.cpp
+++ b/src/widgets/start_screen_widget.cpp
@@ -329,7 +329,7 @@ bool StartScreenWidget::loadExistingFiles()
 
 
   // Check if the old package is a setup assistant package. If it is not, quit
-  if( config_data_->getSetupAssistantYAMLPath(setup_assistant_path) )
+  if( !config_data_->getSetupAssistantYAMLPath(setup_assistant_path) )
   {
     QMessageBox::warning( this, "Incorrect Directory/Package",
                           QString("The chosen package location exists but was not previously created using this MoveIt Setup Assistant. If this is a mistake, replace the missing file: ")

--- a/src/widgets/start_screen_widget.cpp
+++ b/src/widgets/start_screen_widget.cpp
@@ -800,11 +800,6 @@ bool StartScreenWidget::createFullPackagePath()
 {
   // Get package path
   std::string package_path_input = stack_path_->getPath();
-  std::string full_package_path;
-
-  // Trim whitespace from user input
-  boost::trim( package_path_input );
-
   // check that input is provided
   if( package_path_input.empty() )
   {
@@ -812,30 +807,12 @@ bool StartScreenWidget::createFullPackagePath()
     return false;
   }
 
-  // Decide if this is a package name or a full path ----------------------------------------------
-
   // check that the folder exists
-  if( !fs::is_directory( package_path_input ) )
+  if( !config_data_->setPackagePath(package_path_input) )
   {
-    // does not exist, check if its a package
-    full_package_path = ros::package::getPath( package_path_input );
-
-    // check that the folder exists
-    if( !fs::is_directory( full_package_path ) )
-    {
-      // error
-      QMessageBox::critical( this, "Error Loading Files", "The specified path is not a directory or is not accessable" );
-      return false;
-    }
+    QMessageBox::critical( this, "Error Loading Files", "The specified path is not a directory or is not accessable" );
+    return false;
   }
-  else
-  {
-    // they inputted a full path
-    full_package_path = package_path_input;
-  }
-
-  config_data_->config_pkg_path_ = full_package_path;
-
   return true;
 }
 

--- a/src/widgets/start_screen_widget.cpp
+++ b/src/widgets/start_screen_widget.cpp
@@ -324,25 +324,25 @@ bool StartScreenWidget::loadExistingFiles()
   if( !createFullPackagePath() )
     return false; // error occured
 
-  // Path of .setup_assistant file
-  fs::path setup_assistant_file = config_data_->config_pkg_path_;
-  setup_assistant_file /= ".setup_assistant";
+
+  std::string setup_assistant_path;
+
 
   // Check if the old package is a setup assistant package. If it is not, quit
-  if( ! fs::is_regular_file( setup_assistant_file ) )
+  if( config_data_->getSetupAssistantYAMLPath(setup_assistant_path) )
   {
     QMessageBox::warning( this, "Incorrect Directory/Package",
                           QString("The chosen package location exists but was not previously created using this MoveIt Setup Assistant. If this is a mistake, replace the missing file: ")
-                          .append( setup_assistant_file.make_preferred().native().c_str() ) );
+                          .append( setup_assistant_path.c_str() ) );
     return false;
   }
 
   // Get setup assistant data
-  if( !config_data_->inputSetupAssistantYAML( setup_assistant_file.make_preferred().native().c_str() ) )
+  if( !config_data_->inputSetupAssistantYAML( setup_assistant_path ) )
   {
     QMessageBox::warning( this, "Setup Assistant File Error",
                           QString("Unable to correctly parse the setup assistant configuration file: " )
-                          .append( setup_assistant_file.make_preferred().native().c_str() ) );
+                          .append( setup_assistant_path.c_str() ) );
     return false;
   }
 


### PR DESCRIPTION
More than three years ago I have implemented a SRDF updater that  basically wraps `computeDefaultCollisions`. I have now updated it to indigo and added proper argument parsing.

It reads a config package path or explicit URDF and SRDF paths and recalculates the collision pairs that can be disabled.
URDF and SRDF can be xacros and addtional xacro arguments can be passed through.
Another notable option is to keep the existing disabled collision pairs from the input in the output.

Exampe usage:

```
 rosrun moveit_setup_assistant moveit_setup_assistant_updater --config-pkg PATH --trials 100000 -- --inorder
```

@guihomework, @rhaschke: FYI
