### PR TITLE
Allow to conditionally compile against Qt5 by setting -DUseQt5=On

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 2.8.12)
 project(moveit_setup_assistant)
 
 if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
@@ -23,10 +23,19 @@ include_directories(${catkin_INCLUDE_DIRS})
 link_directories(${catkin_LIBRARY_DIRS})
 
 # Qt Stuff
-find_package(Qt4 REQUIRED)
-include(${QT_USE_FILE})
+option(UseQt5 "UseQt5" OFF)
+if (UseQt5)
+  find_package(Qt5Widgets REQUIRED)
+  find_package(Qt5Core REQUIRED)
+  find_package(Qt5OpenGL REQUIRED)
+
+else (UseQt5)
+  find_package(Qt4 REQUIRED COMPONENTS QtCore QtGui QtOpenGL)
+  include(${QT_USE_FILE})
+endif(UseQt5)
+
 add_definitions(-DQT_NO_KEYWORDS)
-include_directories(${QT_INCLUDE_DIR})
+include_directories(${QT_INCLUDE_DIR} ${Qt5Widgets_INCLUDE_DIRS})
 include_directories(${CMAKE_BINARY_DIR})
 
 # Support new yaml-cpp API.
@@ -57,8 +66,10 @@ set( headers
   src/widgets/setup_screen_widget.h
 )
 
+# Instruct CMake to run moc automatically when needed.
+set(CMAKE_AUTOMOC ON)
 # Convert the Qt Signals and Slots for QWidget events
-qt4_wrap_cpp(moc_sources ${headers})
+#qt4_wrap_cpp(moc_sources ${headers})
 
 # Tools Library
 add_library(${PROJECT_NAME}_tools
@@ -86,7 +97,7 @@ add_library(${PROJECT_NAME}_widgets
   src/widgets/header_widget.cpp
   src/widgets/setup_assistant_widget.cpp
   src/widgets/setup_screen_widget.cpp
-  ${moc_sources}
+  ${headers}
 )
 target_link_libraries(${PROJECT_NAME}_widgets ${PROJECT_NAME}_tools ${QT_LIBRARIES} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
@@ -111,8 +122,15 @@ target_link_libraries(${PROJECT_NAME}
   ${PROJECT_NAME}_widgets ${PROJECT_NAME}_tools
   ${QT_LIBRARIES} ${catkin_LIBRARIES} ${Boost_LIBRARIES} log4cxx)
 
+if (UseQt5)
+  target_link_libraries(${PROJECT_NAME} Qt5::Widgets)
+endif (UseQt5)
+
 add_executable(${PROJECT_NAME}_updater src/collisions_updater.cpp )
 target_link_libraries(${PROJECT_NAME}_updater ${PROJECT_NAME}_tools ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+if (UseQt5)
+  target_link_libraries(${PROJECT_NAME}_updater Qt5::Widgets)
+endif (UseQt5)
 set_target_properties(${PROJECT_NAME}_updater
                       PROPERTIES OUTPUT_NAME collisions_updater
                       PREFIX "")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 2.8.11)
 project(moveit_setup_assistant)
 
 if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
@@ -28,6 +28,11 @@ if (UseQt5)
   find_package(Qt5Widgets REQUIRED)
   find_package(Qt5Core REQUIRED)
   find_package(Qt5OpenGL REQUIRED)
+
+  # this can be removed once CMAKE 2.8.12 is available (jade)
+  # it is due to a change in Qts use of -fPIE and -fPIC
+  # http://code.qt.io/cgit/qt/qtbase.git/tree/dist/changes-5.4.2
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${Qt5Core_EXECUTABLE_COMPILE_FLAGS}")
 
 else (UseQt5)
   find_package(Qt4 REQUIRED COMPONENTS QtCore QtGui QtOpenGL)


### PR DESCRIPTION
This allows to conditionally compile and link moveit_setup_assistant against Qt5. It requires the respective pull requests to rviz and moveit_ros to be applied as well.
