### PR TITLE
auto-select Qt version matching the one from rviz

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 2.8.12)
 project(moveit_setup_assistant)
 
 if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
@@ -23,37 +23,28 @@ include_directories(${catkin_INCLUDE_DIRS})
 link_directories(${catkin_LIBRARY_DIRS})
 
 # Qt Stuff
-option(UseQt5 "UseQt5" OFF)
-if (UseQt5)
-  find_package(Qt5Widgets REQUIRED)
-  find_package(Qt5Core REQUIRED)
-  find_package(Qt5OpenGL REQUIRED)
-
-  # this can be removed once CMAKE 2.8.12 is available (jade)
-  # it is due to a change in Qts use of -fPIE and -fPIC
-  # http://code.qt.io/cgit/qt/qtbase.git/tree/dist/changes-5.4.2
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${Qt5Core_EXECUTABLE_COMPILE_FLAGS}")
-
-else (UseQt5)
-  find_package(Qt4 REQUIRED COMPONENTS QtCore QtGui QtOpenGL)
+if(rviz_QT_VERSION VERSION_LESS "5")
+  find_package(Qt4 ${rviz_QT_VERSION} EXACT REQUIRED QtCore QtGui)
   include(${QT_USE_FILE})
-endif(UseQt5)
-
+else()
+  find_package(Qt5 ${rviz_QT_VERSION} EXACT REQUIRED Core Widgets)
+  set(QT_LIBRARIES Qt5::Widgets)
+endif()
+# Instruct CMake to run moc automatically when needed.
+set(CMAKE_AUTOMOC ON)
 add_definitions(-DQT_NO_KEYWORDS)
-include_directories(${QT_INCLUDE_DIR} ${Qt5Widgets_INCLUDE_DIRS})
-include_directories(${CMAKE_BINARY_DIR})
 
 # Support new yaml-cpp API.
 find_package(PkgConfig)
 pkg_check_modules(NEW_YAMLCPP yaml-cpp>=0.5)
 if(NEW_YAMLCPP_FOUND)
-add_definitions(-DHAVE_NEW_YAMLCPP)
+  add_definitions(-DHAVE_NEW_YAMLCPP)
 endif(NEW_YAMLCPP_FOUND)
 
 find_library(YAML yaml-cpp REQUIRED)
 
 # Header files that need Qt Moc pre-processing for use with Qt signals, etc:
-set( headers
+set(HEADERS
   src/widgets/navigation_widget.h
   src/widgets/header_widget.h
   src/widgets/setup_assistant_widget.h
@@ -71,11 +62,6 @@ set( headers
   src/widgets/setup_screen_widget.h
 )
 
-# Instruct CMake to run moc automatically when needed.
-set(CMAKE_AUTOMOC ON)
-# Convert the Qt Signals and Slots for QWidget events
-#qt4_wrap_cpp(moc_sources ${headers})
-
 # Tools Library
 add_library(${PROJECT_NAME}_tools
   src/tools/compute_default_collisions.cpp
@@ -83,7 +69,12 @@ add_library(${PROJECT_NAME}_tools
   src/tools/moveit_config_data.cpp
   src/tools/srdf_writer.cpp
 )
-target_link_libraries(${PROJECT_NAME}_tools ${YAML} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}_tools
+  ${YAML}
+  ${catkin_LIBRARIES}
+  ${Boost_LIBRARIES}
+  ${QT_LIBRARIES}
+)
 
 # Main Widgets Library - all screens (navigation options)
 add_library(${PROJECT_NAME}_widgets
@@ -102,13 +93,13 @@ add_library(${PROJECT_NAME}_widgets
   src/widgets/header_widget.cpp
   src/widgets/setup_assistant_widget.cpp
   src/widgets/setup_screen_widget.cpp
-  ${headers}
+  ${HEADERS}
 )
-target_link_libraries(${PROJECT_NAME}_widgets ${PROJECT_NAME}_tools ${QT_LIBRARIES} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
-
-# Source files for the exectuable
-set( sources
-  src/setup_assistant_main.cpp
+target_link_libraries(${PROJECT_NAME}_widgets
+  ${PROJECT_NAME}_tools
+  ${QT_LIBRARIES}
+  ${catkin_LIBRARIES}
+  ${Boost_LIBRARIES}
 )
 
 catkin_package(
@@ -119,23 +110,17 @@ catkin_package(
   CATKIN_DEPENDS
     moveit_ros_planning
     moveit_ros_visualization
-    )
+)
 
-# Link libraries
-add_executable(${PROJECT_NAME} ${sources} ${headers})
+# executables
+add_executable(${PROJECT_NAME} src/setup_assistant_main.cpp)
 target_link_libraries(${PROJECT_NAME}
   ${PROJECT_NAME}_widgets ${PROJECT_NAME}_tools
   ${QT_LIBRARIES} ${catkin_LIBRARIES} ${Boost_LIBRARIES} log4cxx)
 
-if (UseQt5)
-  target_link_libraries(${PROJECT_NAME} Qt5::Widgets)
-endif (UseQt5)
-
 add_executable(${PROJECT_NAME}_updater src/collisions_updater.cpp )
-target_link_libraries(${PROJECT_NAME}_updater ${PROJECT_NAME}_tools ${catkin_LIBRARIES} ${Boost_LIBRARIES})
-if (UseQt5)
-  target_link_libraries(${PROJECT_NAME}_updater Qt5::Widgets)
-endif (UseQt5)
+target_link_libraries(${PROJECT_NAME}_updater
+  ${PROJECT_NAME}_tools ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 set_target_properties(${PROJECT_NAME}_updater
                       PROPERTIES OUTPUT_NAME collisions_updater
                       PREFIX "")


### PR DESCRIPTION
As setup assistant draws on rviz, it should use exactly the same Qt version to avoid issues.
