### PR TITLE
Compile with C++11 support.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 2.8.12)
 project(moveit_setup_assistant)
 
+add_compile_options(-std=c++11)
+
 if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)
 endif()


### PR DESCRIPTION
Required for FCL 0.5. See also ros-planning/moveit_core#315
