### PR TITLE
write float numbers always in POSIX format

### DIFF
--- a/src/setup_assistant_main.cpp
+++ b/src/setup_assistant_main.cpp
@@ -40,6 +40,7 @@
 #include <QMessageBox>
 #include <boost/program_options.hpp>
 #include <signal.h>
+#include <locale.h>
 
 static void siginthandler(int param)
 {
@@ -81,6 +82,8 @@ int main(int argc, char **argv)
 
   // Create Qt Application
   QApplication qtApp(argc, argv);
+  // numeric values should always be POSIX
+  setlocale(LC_NUMERIC, "C");
 
   // Load Qt Widget
   moveit_setup_assistant::SetupAssistantWidget saw( NULL, vm );


### PR DESCRIPTION
It makes me feel quite sad nobody provided the two-line fix for this issue
over the course of _3_ years. One of the _very first things_ I heard about MoveIt!
in 2013 was @mintar ranting about MoveIt failing to write locale-invariant config files...

Please cherry-pick this to jade and kinetic.

Fixes #51, #107
